### PR TITLE
#6 동작하지 않는 RepeatRunner 와 테스트 작성

### DIFF
--- a/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
+++ b/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
@@ -1,0 +1,12 @@
+package com.bistros.nunit.runner;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.TestClass;
+
+public class RepeatRunner extends BlockJUnit4ClassRunner {
+
+    public RepeatRunner(Class<?> klass) throws InitializationError {
+        super(new TestClass(klass));
+    }
+}

--- a/src/test/java/com/bistros/nunit/runner/IgnoreOnRepeatRunnerTests.java
+++ b/src/test/java/com/bistros/nunit/runner/IgnoreOnRepeatRunnerTests.java
@@ -1,0 +1,43 @@
+package com.bistros.nunit.runner;
+
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestResult;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+public class IgnoreOnRepeatRunnerTests {
+
+    @RunWith(RepeatRunner.class)
+    public static class InnerIgnoreTests {
+        @Ignore
+        @Test
+        public void ignored() {
+        }
+
+        @Test
+        public void run() {
+        }
+    }
+
+    @Test
+    public void ignoreRunner() {
+        JUnitCore runner = new JUnitCore();
+        Result result = runner.run(InnerIgnoreTests.class);
+        assertEquals(1, result.getIgnoreCount());
+        assertEquals(1, result.getRunCount());
+    }
+
+    @Test
+    public void compatibility() {
+        TestResult result = new TestResult();
+        new JUnit4TestAdapter(InnerIgnoreTests.class).run(result);
+        assertEquals(1, result.runCount());
+        assertEquals(0, result.failureCount());
+    }
+
+}

--- a/src/test/java/com/bistros/nunit/runner/SimpleRepeatRunnerTest.java
+++ b/src/test/java/com/bistros/nunit/runner/SimpleRepeatRunnerTest.java
@@ -1,0 +1,18 @@
+package com.bistros.nunit.runner;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RepeatRunner.class)
+public class SimpleRepeatRunnerTest {
+
+    @Test
+    public void testDefaultAssertion() {
+        assertTrue(true);
+        assertEquals("Hello " + "World", "Hello World");
+    }
+
+}


### PR DESCRIPTION
## Description
* 완전히 동작하는 RepeatRunner 를 구현 하는 것은 이 Study 의 끝일 정도로 거대합니다. Phase 를 나누어서 첫 번째로 `@RunWith`에서도 동작하는 Runner 를 만들었습니다.


## Comment
JUnit 4는 `@RunWith` 와 Runner 구현 클래스를 이용하여  테스트 환경, 실행, 리포팅등을 변경 할 수 있습니다.
기존 4.4까지는 JUnit4ClassRunner  default runner 였지만 4.5 이상부터는 BlockJUnit4ClassRunner 가 그 역할을 대신하고 있습니다.

### JUnit4 Runner 의 Default Runner 인 BlockJUnit4ClassRunner 클래스와 하위 클래스에 대하여...
1. BlockJUnit4ClassRunnerWithParameters
   * 기본 JUnit 에 '파라미터' 를 이용할 수 있도록 작성된 Runner 
1. JUnit4
   * Final class 이고 현재 Default Runner의 Alias 용도이다.
    그렇다면 별 기능이 없어야 하는데 생성자 부분에서  `new TestClass(clazz)` 코드가 존재한다.
    이 Runner 만의 특별한 기능인 줄 알았지만, https://git.io/Jf1AM 를 확인해보면 4.12 이후 deprecated 되는 메소드를 변경한 것으로 보인다. 그래서 내가 만드는 Runner 도 TestClass 인스턴스를 생성자에 이용하는게 좋겟다.
1. BlockJUnit4ClassRunner
   * Suite 나 Parameterized 를 제외하고 가장 기본이 되는 Runner이다. JUnit4ClassRunner가 deprecated 된 이후 default Runner가 되었다.
  
