### PR TITLE
#7 RepeatRunner 에서 Repeat Annotation 을 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,3 +36,9 @@ pmd {
     rulePriority = 2
     ruleSetFiles = rootProject.files('config/pmd/all-java.xml')
 }
+
+test {
+    reports {
+        html.enabled = true
+    }
+}

--- a/src/main/java/com/bistros/nunit/annotation/Repeat.java
+++ b/src/main/java/com/bistros/nunit/annotation/Repeat.java
@@ -1,0 +1,12 @@
+package com.bistros.nunit.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Repeat {
+    int value() default 1;
+}

--- a/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
+++ b/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
@@ -1,12 +1,31 @@
 package com.bistros.nunit.runner;
 
+import com.bistros.nunit.annotation.Repeat;
+import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.TestClass;
+
+import java.util.Optional;
 
 public class RepeatRunner extends BlockJUnit4ClassRunner {
 
     public RepeatRunner(Class<?> klass) throws InitializationError {
         super(new TestClass(klass));
     }
+
+    @Override
+    protected void runChild(final FrameworkMethod method, RunNotifier notifier) {
+        repeatable(method, notifier);
+    }
+
+    private void repeatable(FrameworkMethod method, RunNotifier notifier) {
+        int repeat = Optional.ofNullable(method.getAnnotation(Repeat.class))
+                .map(Repeat::value).orElse(1);
+        for (int i = 0; i < repeat; i++) {
+            super.runChild(method, notifier);
+        }
+    }
+
 }

--- a/src/test/java/com/bistros/nunit/RepeatTests.java
+++ b/src/test/java/com/bistros/nunit/RepeatTests.java
@@ -1,0 +1,49 @@
+package com.bistros.nunit;
+
+import com.bistros.nunit.annotation.Repeat;
+import com.bistros.nunit.runner.RepeatRunner;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RepeatTests {
+
+    @RunWith(RepeatRunner.class)
+    public static class InnerRepeatTest {
+        @Test
+        @Repeat(3)
+        public void testRun3Times() {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void repeat() {
+        JUnitCore runner = new JUnitCore();
+        Result result = runner.run(InnerRepeatTest.class);
+        assertEquals(0, result.getIgnoreCount());
+        assertEquals(3, result.getRunCount());
+    }
+
+
+    @RunWith(RepeatRunner.class)
+    public static class InnerRepeatTest2 {
+        @Test
+        public void testRun1TimeNoWithRepeat() {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void repeat2() {
+        JUnitCore runner = new JUnitCore();
+        Result result = runner.run(InnerRepeatTest2.class);
+        assertEquals(0, result.getIgnoreCount());
+        assertEquals(1, result.getRunCount());
+    }
+
+}

--- a/src/test/java/example/ExampleRepeatTests.java
+++ b/src/test/java/example/ExampleRepeatTests.java
@@ -1,0 +1,17 @@
+package example;
+
+import com.bistros.nunit.annotation.Repeat;
+import com.bistros.nunit.runner.RepeatRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RepeatRunner.class)
+public class ExampleRepeatTests {
+    @Test
+    @Repeat(3)
+    public void repeatTest() {
+        assertTrue(true);
+    }
+}


### PR DESCRIPTION
## Description
* JUnit 의  Class Level  Annotation (BeforeClass 등) 은 ParentRunner의 classBlock 에서 처리하고,   Method Annotation (Before , Rule 등)은  https://git.io/Jf1pN 에서 처리한다. 
  가장 좋은 방법으로 생각되는 것은 methodBlock 안에서 `withRepeat(...)` 를 구현 하는 것이라 생각되지만  이 방법은 몇가지 아쉬운 점이 있다. 

우선 구현 가능한 방법은 아래처럼 생각된다.

1. protected methodBlock 를 통으로 copy & paste 해서 override 하는 방법
   * withRules  가 private method 이므로 리플렉션을 통해서 호출 해야 하는 점
   * New Features 를 위해서 기존의 메소드를 통으로 복사한 다는 점
1. methodBlock 에서 super.methodBlock 를 호출하는 방법
   * methodBlock의 제일 첫 부분 (possiblyExpectingExceptions) 또는 제일 마지막 부분 ( withInterruptIsolation ) 에 `withRepeat`를 적용할  수 있다. 해보지는 않았지만 기본 테스트 동작과 어긋날 것 같다.
   *  `Object test = createTest(...)`   가 methodBlock scope 이다. 이  test 인스턴스가 필요하다면 다시 한번 createTest() 를 해야한다.
1. methodBlock 에서 호출하는 상속 가능한 `withInterruptIsolation` 를  확장 하는 방법
   * 간편하지만 메소드 명과 행동이 달라진다. (withInterruptIsolation 안에서 repeat를 처리한다?)
1. methodBlock 이 아닌, 그 상위에서 loop를 돌려볼 것

## Comment
* 시작은 간단하게!
* BlockJUnit4ClassRunner 에서 runChild 는 테스트마다 호출된다. 그리고 확장 가능한 protected 이다.
* 여기 안에서 Repeat Annotation 을 처리하는 것 부터 시작한다. (기능이 부족해야... 기능도 개선할 수 있다-_-)

아래의 테스트 코드를 작성하면 첨부 이미지와 같은 결과를 확인 할 수 있다.
```
@RunWith(RepeatRunner.class)
public class ExampleRepeatTests {
    @Test
    @Repeat(3)
    public void repeatTest() {
        assertTrue(true);
    }
}

```

<img width="436" alt="스크린샷 2020-06-07 오전 11 13 13" src="https://user-images.githubusercontent.com/3212448/83958706-e7356200-a8af-11ea-85e1-c9df981e2e26.png">
