### PR TITLE
Method 에 적용하는 Repeat 순서를 재정의 함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'idea'
     id 'checkstyle'
     id 'pmd'
+    id "nebula.facet" version "7.0.9" //v7.0.0, nebula-project-plugin supports only Gradle 5.0+
 }
 
 
@@ -41,4 +42,23 @@ test {
     reports {
         html.enabled = true
     }
+}
+
+facets {
+    integTest
+}
+
+task combineTestReport(type: TestReport) {
+    destinationDir = file("$buildDir/reports/combined")
+    reportOn test
+    reportOn integTest
+}
+
+check.dependsOn combineTestReport
+
+gradle.buildFinished {
+    println "====Report List===="
+    println "Checkstyle: " + checkstyleMain.reports.getHtml().destination.toURI()
+    println "Pmd       : " + pmdMain.reports.html.destination.toURI()
+    println "Test      : " + combineTestReport.destinationDir.toURI()
 }

--- a/src/integTest/java/example/timeout/ExampleTimeoutContinousTest.java
+++ b/src/integTest/java/example/timeout/ExampleTimeoutContinousTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 public class ExampleTimeoutContinousTest {
 
     //Continuous 으로 실행 할때 Timeout이 발생하는 테스트. 주석을 제거하고 확인 가능하다.
-    @Test(timeout = 2000)
+    //@Test(timeout = 2000)
     @Repeat(value = 3, mode = Repeat.Mode.CONTINUOUS)
     public void testDecreases3TimesContinuousMode() throws InterruptedException {
         Thread.sleep(1000);

--- a/src/integTest/java/example/timeout/ExampleTimeoutContinousTest.java
+++ b/src/integTest/java/example/timeout/ExampleTimeoutContinousTest.java
@@ -1,0 +1,22 @@
+package example.timeout;
+
+import com.bistros.nunit.annotation.Repeat;
+import com.bistros.nunit.runner.RepeatRunner;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(RepeatRunner.class)
+public class ExampleTimeoutContinousTest {
+
+    //Continuous 으로 실행 할때 Timeout이 발생하는 테스트. 주석을 제거하고 확인 가능하다.
+    @Test(timeout = 2000)
+    @Repeat(value = 3, mode = Repeat.Mode.CONTINUOUS)
+    public void testDecreases3TimesContinuousMode() throws InterruptedException {
+        Thread.sleep(1000);
+    }
+
+    @Test
+    public void testForKeepClass() {
+    }
+}

--- a/src/integTest/java/example/timeout/ExampleTimeoutIndependentTest.java
+++ b/src/integTest/java/example/timeout/ExampleTimeoutIndependentTest.java
@@ -5,7 +5,6 @@ import com.bistros.nunit.annotation.Repeat;
 import com.bistros.nunit.runner.RepeatRunner;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,7 +17,8 @@ public class ExampleTimeoutIndependentTest {
         Thread.sleep(1000);
         Assert.assertTrue(true);
     }
-    @Before
+
+    @Test
     public void testForKeepClass() {
     }
 

--- a/src/integTest/java/example/timeout/ExampleTimeoutIndependentTest.java
+++ b/src/integTest/java/example/timeout/ExampleTimeoutIndependentTest.java
@@ -1,0 +1,25 @@
+package example.timeout;
+
+import com.bistros.nunit.annotation.Repeat;
+
+import com.bistros.nunit.runner.RepeatRunner;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(RepeatRunner.class)
+public class ExampleTimeoutIndependentTest {
+
+    @Test(timeout = 3000)
+    @Repeat(value = 4, mode = Repeat.Mode.INDEPENDENT)
+    public void testDecreases3TimesIndependentMode() throws InterruptedException {
+        Thread.sleep(1000);
+        Assert.assertTrue(true);
+    }
+    @Before
+    public void testForKeepClass() {
+    }
+
+}

--- a/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
+++ b/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
@@ -100,8 +100,8 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
 
         Statement statement = methodInvoker(method, test);
         statement = possiblyExpectingExceptions(method, test, statement);
-        statement = withPotentialTimeout(method, test, statement);
         statement = withRepeat(method, test, statement);    //add
+        statement = withPotentialTimeout(method, test, statement);
         statement = withBefores(method, test, statement);
         statement = withAfters(method, test, statement);
         statement = withRulesCustomize(method, test, statement); //custom

--- a/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
+++ b/src/main/java/com/bistros/nunit/runner/RepeatRunner.java
@@ -101,10 +101,10 @@ public class RepeatRunner extends BlockJUnit4ClassRunner {
         Statement statement = methodInvoker(method, test);
         statement = possiblyExpectingExceptions(method, test, statement);
         statement = withPotentialTimeout(method, test, statement);
+        statement = withRepeat(method, test, statement);    //add
         statement = withBefores(method, test, statement);
         statement = withAfters(method, test, statement);
         statement = withRulesCustomize(method, test, statement); //custom
-        statement = withRepeat(method, test, statement);    //add
         statement = withInterruptIsolation(statement);
         return statement;
     }


### PR DESCRIPTION
## Description
Rule 다음에 Repeat 를 넣으면 Repeat 를 넣음으로 기존의 Junit 동작과 달라지게 되었다. 

현재는 Repeat 의 수행시간이 Test(timeout) 과 상관없이 독립적으로 수행되고 있고 이 부분을 개선한 PR 이다.

methodBlock 에서 Statements 를 선언하는 channing 순서를 변경함으로써 처리하였다.


## Comment

테스트가 부족한 부분)
이 PR 을 올리기 위해 Timeout + Mode.Continous 를 테스트 할 필요가 있었다.  

```
public class Test {

    @RunWith(RepeatRunner.class)
    public static class InnerTimeoutTest {
            @Test(timeout = 2000)
            @Repeat(value = 3, mode = Repeat.Mode.CONTINUOUS)
            public void testDecreases3TimesContinuousMode() throws InterruptedException {
                Thread.sleep(1000);
            }
        }


        @Test
        public void wanted() {
            JUnitCore runner = new JUnitCore();
            Result result = runner.runClasses(Dele.InnerTimeoutTest.class);

            System.out.println(result);
            long timeoutExceptionCount = result.getFailures()
                .stream().filter(c -> c.getException() instanceof TestTimedOutException).count();
            Assert.assertEquals(1, timeoutExceptionCount);
        }
    }
}

```
그래서  위의 코드처럼 Exception 을 잡는 테스트를 작성하고자 했다
InnerTimeoutTest 클래스가 wanted() 에서 수행 될때는 원하는대로 되었지만, 전체 Project Test를 돌릴 때에는  `Test$InnerTimeoutTest` 으로 테스트대상에 포함되어서 항상 Fail Test가 발생하였다.

이 이슈를 해결하기하지 못해 우선은 '주석 처리'를 하여 해당 테스트를 배제하였고, 해당 테스트는 좀 더 고민이 필요함